### PR TITLE
Update ThingProperty.h

### DIFF
--- a/src/ThingProperty.h
+++ b/src/ThingProperty.h
@@ -118,7 +118,7 @@ public:
 
         if (atType != nullptr)
         {
-            obj["@contextType"] = atType;
+            obj["@type"] = atType;
         }
     }
 


### PR DESCRIPTION
Changed `@contextType` --> `@type` . As specified in WebThing Schema.

As per the web thing schema we need to define one or more device capability types as a top-level @type array and define at least the required properties, actions, and events for those capabilities with an appropriate @type annotation.

To maintain schema compatibility with webthings. 
